### PR TITLE
[BUGFIX] gluonnlp.data.batchify.StreamBPTTBatchify

### DIFF
--- a/src/gluonnlp/data/batchify/language_model.py
+++ b/src/gluonnlp/data/batchify/language_model.py
@@ -285,7 +285,7 @@ class _StreamBPTTBatchify(DataStream):
         def _read(buffers, i, vocab, corpus):
             """Read a sentence from the corpus into i-th buffer."""
             if len(buffers[i]) <= 1:
-                buffers[i].extend(vocab[next(corpus)])
+                buffers[i].append(vocab[next(corpus)])
 
         def _write(data, target, buffers, seq_len, i, length):
             """Write a sentence from i-th buffer to data and target."""


### PR DESCRIPTION
## Description ##
Tiny fix for `gluonnlp.data.batchify.StreamBPTTBatchify`

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
I may be misunderstanding how StreamBPTTBatchify is intended to be used, but it seems like
```
Traceback (most recent call last):
  [...]
  File "gluon-nlp/src/gluonnlp/data/batchify/language_model.py", line 321, in __iter__
    _read(buffers, i, self._vocab, corpus)
  File "gluon-nlp/src/gluonnlp/data/batchify/language_model.py", line 291, in _read
    buffers[i].extend(vocab[v])
TypeError: 'int' object is not iterable
```
is unavoidable due to the transformation on lines 307-310 of this file.  I think the original author intended `.append()` rather than `.extend()` but I'm not totally confident.